### PR TITLE
Travis CI: Add Python 3.7 and Remove the EOLed 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: python
-sudo: false
 python:
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
   - 3.6
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
 install: python setup.py install
 script: python setup.py test


### PR DESCRIPTION
Also Travis CI is deprecating the keyword 'sudo'
* https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration